### PR TITLE
Fix RTL languages support in weasley-card

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ I decided to make it public so that other (more skillful) people could make use 
 * Hand colour (and text colour on the hands) can be customised for each person
 * Hands animate fairly smoothly between states
 * "Lost" and "Travelling" state text can be customised
+* Supports right-to-left (RTL) languages like Hebrew and other RTL languages
 
 
 ## Installation

--- a/weasley-card.js
+++ b/weasley-card.js
@@ -192,7 +192,7 @@ class WeasleyClockCard extends HTMLElement {
           var startAngle = 0; 
           var inwardFacing = true;
           var kerning = 0; // can adjust kerning using this - maybe automatically adjust it based on text length? 
-          var text = this.isRtlLanguage(locations[num]) ? locations[num] : locations[num].split("").reverse().join("");
+          var text = locations[num].split("").reverse().join("");
           // if we're in the bottom half of the clock then reverse the facing of the text so that it's not upside down
           if (ang > Math.PI / 2 && ang < ((Math.PI * 2) - (Math.PI / 2))) 
           {
@@ -200,6 +200,8 @@ class WeasleyClockCard extends HTMLElement {
             inwardFacing = false;
             text = locations[num];
           }
+
+          text = this.isRtlLanguage(text) ? text.split("").reverse().join("") : text;
 
           // calculate height of the font. Many ways to do this - you can replace with your own!
           var div = document.createElement("div");

--- a/weasley-card.js
+++ b/weasley-card.js
@@ -192,7 +192,7 @@ class WeasleyClockCard extends HTMLElement {
           var startAngle = 0; 
           var inwardFacing = true;
           var kerning = 0; // can adjust kerning using this - maybe automatically adjust it based on text length? 
-          var text = locations[num].split("").reverse().join("");
+          var text = this.isRtlLanguage(locations[num]) ? locations[num] : locations[num].split("").reverse().join("");
           // if we're in the bottom half of the clock then reverse the facing of the text so that it's not upside down
           if (ang > Math.PI / 2 && ang < ((Math.PI * 2) - (Math.PI / 2))) 
           {
@@ -241,7 +241,10 @@ class WeasleyClockCard extends HTMLElement {
       }
   }
 
-
+  isRtlLanguage(text) {
+    const rtlChar = /[\u0590-\u05FF\u0600-\u06FF\u0750-\u077F\u08A0-\u08FF\uFB50-\uFDFF\uFE70-\uFEFF]/;
+    return rtlChar.test(text);
+  }
 
   drawTime(ctx, radius, locations, wizards){
       this.targetstate = [];


### PR DESCRIPTION
Modify the `drawNumbers` function in `weasley-card.js` to support right-to-left (RTL) languages.

* Add a helper function `isRtlLanguage` to detect if the text is in an RTL language.
* Update the `drawNumbers` function to check if the text is in an RTL language and not reverse it.
* Update the `README.md` file to mention that the component supports RTL languages like Hebrew and other RTL languages.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/baruchiro/WizardClock?shareId=0a9326ed-b671-48a0-95c6-afe1d75dd79a).